### PR TITLE
Revert "Redirects from NRG Common JavaDoc publishing root to sub-project docs (#3)"

### DIFF
--- a/nrgcommon/javadoc/index.html
+++ b/nrgcommon/javadoc/index.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<meta charset="UTF-8">
-<title>Redirecting to NRG Common Javadoc</title>
-<meta http-equiv="refresh" content="0; URL='nrgcommon/javadoc'">
-<link rel="canonical" href="nrgcommon/javadoc">


### PR DESCRIPTION
This reverts commit b9268d23d1f61d23a7fbb64bfd05b2a1e5c59c22.